### PR TITLE
Correct method for declaring floats

### DIFF
--- a/Aimbot.cpp
+++ b/Aimbot.cpp
@@ -8,7 +8,7 @@ Rust::Aimbot::Aimbot()
 {
 	Rust::Globals::hack_setting.Aimbot.enable = true;
 	Rust::Globals::hack_setting.Aimbot.prediction = true;
-	Rust::Globals::hack_setting.Aimbot.fov = 400.f;
+	Rust::Globals::hack_setting.Aimbot.fov = 400f;
 }
 
 
@@ -52,8 +52,8 @@ void Rust::Aimbot::exec()
 
 bool Rust::Aimbot::FindTarget()
 {
-	float CurrentNearDistance = 10000.f;
-	Cheat::Vector2 ScreenMiddle = { Rust::Globals::system_data.width/2.f, Rust::Globals::system_data.height / 2.f }; // rect 좌표로 하지 말 것 왜냐하면 world2screen 값은 오프셋이기 때문
+	float CurrentNearDistance = 10000f;
+	Cheat::Vector2 ScreenMiddle = { Rust::Globals::system_data.width/2f, Rust::Globals::system_data.height / 2f }; // rect 좌표로 하지 말 것 왜냐하면 world2screen 값은 오프셋이기 때문
 
 	Rust::CheatStruct::Player* pTarget = NULL;
 	for (const auto& PlayerObject : Rust::Globals::hack_data.TaggedObject.map) {

--- a/Aimbot.h
+++ b/Aimbot.h
@@ -28,12 +28,12 @@ namespace Rust {
 
 		float to_radian(float degree)
 		{
-			return degree * 3.141592f / 180.f;
+			return degree * 3.141592f / 180f;
 		}
 
 		float to_degree(float radian)
 		{
-			return radian * 180.f / 3.141592f;
+			return radian * 180f / 3.141592f;
 		}
 		
 		void Normalize(float& Yaw, float& Pitch) { // OnlyDegree // 위 일때 pitch 은 음수값 아래일때 pitch + 값 yaw 은 -360~360

--- a/Helpers.cpp
+++ b/Helpers.cpp
@@ -20,8 +20,8 @@ bool Rust::MainCam::WorldToScreen(const XMFLOAT4X4 & ViewProjMatrix, const Cheat
 	float XXXX = XMVectorGetX(XMVector4Dot(right, pos)) + matrix._14;
 	float YYYY = XMVectorGetX(XMVector4Dot(up, pos)) + matrix._24;
 
-	screenpos.x = (int)(width / 2) * (1.f + XXXX / depth);
-	screenpos.y = (int)(height / 2) * (1.f - YYYY / depth);
+	screenpos.x = (int)(width / 2) * (1f + XXXX / depth);
+	screenpos.y = (int)(height / 2) * (1f - YYYY / depth);
 
 	return true;
 }
@@ -45,11 +45,11 @@ bool Rust::Helpers::WorldToScreen(const XMFLOAT4X4 & ViewProjMatrix, const Cheat
 	float XXXX = XMVectorGetX(XMVector4Dot(right, pos)) + matrix._14;
 	float YYYY = XMVectorGetX(XMVector4Dot(up, pos)) + matrix._24;
 
-	float fovXrad = fovX * 3.141592f / 180.f;
+	float fovXrad = fovX * 3.141592f / 180f;
 	float fovYrad = fovXrad * height / width;
 
-	screenpos.x = (int)(width / 2) * (1.f + XXXX  / depth);
-	screenpos.y = (int)(height / 2) * (1.f - YYYY / depth);
+	screenpos.x = (int)(width / 2) * (1f + XXXX  / depth);
+	screenpos.y = (int)(height / 2) * (1f - YYYY / depth);
 
 	return true;
 }
@@ -72,11 +72,11 @@ bool Rust::Helpers::WorldToScreenViewMatrix(const DirectX::XMFLOAT4X4 & ViewMatr
 	float XXXX = XMVectorGetX(XMVector4Dot(right, pos));
 	float YYYY = XMVectorGetX(XMVector4Dot(up, pos));
 
-	float fovXrad = fovX * 3.141592f / 180.f;
+	float fovXrad = fovX * 3.141592f / 180f;
 	float fovYrad = fovXrad * height / width;
 
-	screenpos.x = (int)(width / 2) * (1.f + XXXX / fovXrad / depth);
-	screenpos.y = (int)(height / 2) * (1.f - YYYY / fovYrad / depth);
+	screenpos.x = (int)(width / 2) * (1f + XXXX / fovXrad / depth);
+	screenpos.y = (int)(height / 2) * (1f - YYYY / fovYrad / depth);
 
 	return true;
 
@@ -89,9 +89,9 @@ bool Rust::Helpers::WorldToScreenTest(const DirectX::XMFLOAT4X4 & worldtoClipSpa
 	XMVECTOR worldPOS = XMLoadFloat4(&(XMFLOAT4)worldpos);
 	XMMATRIX viewproj = XMLoadFloat4x4(&viewProj);
 	XMVECTOR screenVec = DirectX::XMVector3Project(worldPOS, 0, 0, width, height,
-		0.1f, 3000.f, DirectX::XMMatrixIdentity(), viewproj, DirectX::XMMatrixIdentity());
+		0.1f, 3000f, DirectX::XMMatrixIdentity(), viewproj, DirectX::XMMatrixIdentity());
 
-	if (DirectX::XMVectorGetZ(screenVec) < 1.f)
+	if (DirectX::XMVectorGetZ(screenVec) < 1f)
 		return false;
 
 	DirectX::XMStoreFloat2((XMFLOAT2*)(&screenpos), screenVec);

--- a/Misc.cpp
+++ b/Misc.cpp
@@ -9,7 +9,7 @@ Rust::Misc::Misc()
 
 	Rust::Globals::hack_setting.Misc.VelocityScale.enable = true;
 	Rust::Globals::hack_setting.Misc.VelocityScale.changed = true;
-	Rust::Globals::hack_setting.Misc.VelocityScale.multiplier = 100.f;
+	Rust::Globals::hack_setting.Misc.VelocityScale.multiplier = 100f;
 
 	Rust::Globals::hack_setting.Misc.FastGather.enable = true;
 	Rust::Globals::hack_setting.Misc.FastGather.changed = true;
@@ -86,13 +86,13 @@ void Rust::Misc::ModifyItems()
 			m_ModdedWeaponList[item] = recoil;
 
 			//no spread
-			RecoilSpread[0] = 0.f;
-			RecoilSpread[1] = 0.f;
+			RecoilSpread[0] = 0f;
+			RecoilSpread[1] = 0f;
 			//x0.2 recoil
 			RecoilSpread[2] *= 0.2f;
 			RecoilSpread[3] *= 0.2f;
 			//movement penalty;
-			RecoilSpread[5] = 0.f;
+			RecoilSpread[5] = 0f;
 
 			Rust::Globals::hack_data.RustMemory->WriteRaw(RecoilSpread, (void*)(RecoilProperties + 0x28), sizeof(RecoilSpread));
 		}

--- a/Visual.cpp
+++ b/Visual.cpp
@@ -16,12 +16,12 @@ Rust::Visual::Visual()
 
 	setting::ObjectSetting player;
 	player.color = D2D1::ColorF::Enum::Green;
-	player.distance = 250.f;
+	player.distance = 250f;
 	player.enable = true;
 
 	setting::ObjectSetting corpse;
 	corpse.color = D2D1::ColorF::Enum::LightSkyBlue;
-	corpse.distance = 50.f;
+	corpse.distance = 50f;
 	corpse.enable = true;
 
 	Rust::Globals::hack_setting.Visual.TaggedObjectSettingInfo[Rust::ObjectTag::PLAYER] = player;
@@ -29,32 +29,32 @@ Rust::Visual::Visual()
 
 	setting::ObjectSetting collectables;
 	collectables.color = D2D1::ColorF::Enum::LightCoral;
-	collectables.distance = 150.f;
+	collectables.distance = 150f;
 	collectables.enable = true;
 
 	setting::ObjectSetting ores;
 	ores.color = D2D1::ColorF::Enum::LightCyan;
-	ores.distance = 150.f;
+	ores.distance = 150f;
 	ores.enable = true;
 
 	setting::ObjectSetting foods;
 	foods.color = D2D1::ColorF::Enum::LightYellow;
-	foods.distance = 50.f;
+	foods.distance = 50f;
 	foods.enable = true;
 
 	setting::ObjectSetting constructions;
 	constructions.color = D2D1::ColorF::Enum::LightGray;
-	constructions.distance = 50.f;
+	constructions.distance = 50f;
 	constructions.enable = true;
 
 	setting::ObjectSetting loot;
 	loot.color = D2D1::ColorF::Enum::LightSkyBlue;
-	loot.distance = 150.f;
+	loot.distance = 150f;
 	loot.enable = true;
 
 	setting::ObjectSetting animals;
 	animals.color = D2D1::ColorF::Enum::Lime;
-	animals.distance = 100.f;
+	animals.distance = 100f;
 	animals.enable = true;
 
 	Rust::Globals::hack_setting.Visual.ActiveObjectSettingInfo[Rust::CheatStruct::ActiveObject::Info::Type::animals] = animals;
@@ -65,8 +65,8 @@ Rust::Visual::Visual()
 	Rust::Globals::hack_setting.Visual.ActiveObjectSettingInfo[Rust::CheatStruct::ActiveObject::Info::Type::ores] = ores;
 
 
-	Rust::Globals::hack_setting.Visual.TAGGED_OBJECT_CATCH_DISTANCE = 300.f;
-	Rust::Globals::hack_setting.Visual.ACTIVE_OBJECT_CATCH_DISTANCE = 250.f;
+	Rust::Globals::hack_setting.Visual.TAGGED_OBJECT_CATCH_DISTANCE = 300f;
+	Rust::Globals::hack_setting.Visual.ACTIVE_OBJECT_CATCH_DISTANCE = 250f;
 }
 
 
@@ -102,9 +102,9 @@ void Rust::Visual::DrawTaggedObject()
 			float BoxHeight = player->ScreenPos.y - player->ScreenHeadPos.y;
 			float BoxWidth = BoxHeight / 1.5f;
 
-			if (BoxHeight < 5.f) {
-				BoxWidth = 5.f;
-				BoxHeight = 10.f;
+			if (BoxHeight < 5f) {
+				BoxWidth = 5f;
+				BoxHeight = 10f;
 			}
 
 			Vector4 Border;
@@ -119,7 +119,7 @@ void Rust::Visual::DrawTaggedObject()
 				Draw2DBox(Border, Rust::Globals::hack_setting.Visual.TaggedObjectSettingInfo[Rust::ObjectTag::PLAYER].color);
 
 			DrawHealthBar(player->Health, Border);
-			DrawNameAndDistance(player->Name, std::to_wstring(player->Distance).c_str(), { player->ScreenPos.x, player->ScreenPos.y + 15.f });
+			DrawNameAndDistance(player->Name, std::to_wstring(player->Distance).c_str(), { player->ScreenPos.x, player->ScreenPos.y + 15f });
 			DrawPlayerWeapon();
 			DrawRadar();
 		}
@@ -175,22 +175,22 @@ void Rust::Visual::DrawHealthBar(int health, const Cheat::Vector4 & Border)
 	float BoxHeight = Border.w - Border.y;
 	float BoxWIidth = Border.z - Border.x;
 
-	float HealthBarHeight = 0.f;
+	float HealthBarHeight = 0f;
 
-	HealthBarHeight = (BoxHeight / 100.f) * health;
+	HealthBarHeight = (BoxHeight / 100f) * health;
 
 	Vector4 BoxRect;
 	Vector4 BoxBorder;
 	float thickness = 5.0f;
 
-	BoxRect.x = Border.x - thickness - 3.f;
+	BoxRect.x = Border.x - thickness - 3f;
 	BoxRect.y = Border.w - HealthBarHeight;
-	BoxRect.z = Border.x - 3.f;
+	BoxRect.z = Border.x - 3f;
 	BoxRect.w = Border.w;
 
-	BoxBorder.x = Border.x - thickness - 3.f;
+	BoxBorder.x = Border.x - thickness - 3f;
 	BoxBorder.y = Border.y;
-	BoxBorder.z = Border.x - 3.f;
+	BoxBorder.z = Border.x - 3f;
 	BoxBorder.w = Border.w;
 
 	m_renderer.DrawRect(BoxBorder, 0.0000001f, D2D1::ColorF::Enum::Black, 1.0f, true, D2D1::ColorF::Enum::Black, 1.0f);
@@ -200,9 +200,9 @@ void Rust::Visual::DrawHealthBar(int health, const Cheat::Vector4 & Border)
 void Rust::Visual::DrawCorsshair(D2D1::ColorF::Enum color)
 {
 	float thickness = 1.2f;
-	float length = 13.f;
-	float width = Rust::Globals::system_data.width/2.f;
-	float height = Rust::Globals::system_data.height/2.f;
+	float length = 13f;
+	float width = Rust::Globals::system_data.width/2f;
+	float height = Rust::Globals::system_data.height/2f;
 
 	Cheat::Vector4 H = {
 		width - length,


### PR DESCRIPTION
To declare a number as float, a prefix 'f' is added to it.
e.g. 15  -> int
     15. -> double
     15f -> float
Using both (15.f) is redundant.
All the files have been modified to use the correct method:
i.e. 15f rather that 15.f